### PR TITLE
Closing copy() method for models issue.

### DIFF
--- a/src/main/java/com/loadero/http/ApiResource.java
+++ b/src/main/java/com/loadero/http/ApiResource.java
@@ -39,6 +39,21 @@ public enum ApiResource {
         return controller.request(method, url, content, clazz);
     }
 
+    /**
+     * Overloads request() method above to avoid unnecessary serialization
+     * of *Params object during copy operation.
+     */
+    public static <T> T request(
+        RequestMethod method, String url, Class<T> clazz, String name
+    ) throws IOException {
+        String content = String.format(
+            "{"
+            + "\"name\":\"%s\""
+            + "}", name
+        );
+        return controller.request(method, url, content, clazz);
+    }
+
     public static Gson getGSON() {
         return gson;
     }

--- a/src/main/java/com/loadero/model/Assert.java
+++ b/src/main/java/com/loadero/model/Assert.java
@@ -83,6 +83,19 @@ public final class Assert {
         ApiResource.request(RequestMethod.DELETE, route, null, Assert.class);
     }
 
+    /**
+     * Duplicates assert.
+     *
+     * @param testId ID of the test.
+     * @param assertId ID of an assert.
+     * @return Copy of {@link Assert} with new ID.
+     * @throws IOException if request failed.
+     */
+    public static Assert copy(int testId, int assertId) throws IOException {
+        String route = buildRoute(testId, assertId) + "copy/";
+        return ApiResource.request(RequestMethod.POST, route, null, Assert.class);
+    }
+
     private static String buildRoute(int testId) {
         return String.format("%s/tests/%s/asserts/", Loadero.getProjectUrl(), testId);
     }

--- a/src/main/java/com/loadero/model/Group.java
+++ b/src/main/java/com/loadero/model/Group.java
@@ -78,6 +78,20 @@ public final class Group {
         ApiResource.request(RequestMethod.DELETE, route, null, Group.class);
     }
 
+    /**
+     * Duplicates group with new name.
+     *
+     * @param testId ID of the test.
+     * @param groupId ID of the group.
+     * @param name Name of the copy.
+     * @return Copy of {@link Group} with new name and ID.
+     * @throws IOException if request failed.
+     */
+    public static Group copy(int testId, int groupId, String name) throws IOException {
+        String route = buildRoute(testId, groupId) + "copy/";
+        return ApiResource.request(RequestMethod.POST, route, Group.class, name);
+    }
+
     private static String buildRoute(int testId) {
         return String.format("%s/tests/%s/groups/", Loadero.getProjectUrl(), testId);
     }

--- a/src/main/java/com/loadero/model/Participant.java
+++ b/src/main/java/com/loadero/model/Participant.java
@@ -5,6 +5,7 @@ import com.loadero.http.ApiResource;
 import com.loadero.http.RequestMethod;
 import com.loadero.types.AudioFeed;
 import com.loadero.types.Browser;
+import com.loadero.types.BrowserLatest;
 import com.loadero.types.ComputeUnit;
 import com.loadero.types.Location;
 import com.loadero.types.MediaType;
@@ -105,6 +106,22 @@ public final class Participant {
     public static void delete(int testId, int groupId, int participantId) throws IOException {
         String route = buildRoute(testId, groupId, participantId);
         ApiResource.request(RequestMethod.DELETE, route, null, Participant.class);
+    }
+
+    /**
+     * Duplicates participant with new name.
+     *
+     * @param testId ID of the test.
+     * @param groupId ID of the group.
+     * @param participantId ID of the participant.
+     * @param name Name of the copy.
+     * @return Copy of {@link Participant} with new name and ID.
+     * @throws IOException if request failed.
+     */
+    public static Participant copy(int testId, int groupId, int participantId, String name)
+        throws IOException {
+        String route = buildRoute(testId, groupId, participantId) + "copy/";
+        return ApiResource.request(RequestMethod.POST, route, Participant.class, name);
     }
 
     private static String buildRoute(int testId, int groupId) {

--- a/src/main/java/com/loadero/model/Participant.java
+++ b/src/main/java/com/loadero/model/Participant.java
@@ -5,7 +5,6 @@ import com.loadero.http.ApiResource;
 import com.loadero.http.RequestMethod;
 import com.loadero.types.AudioFeed;
 import com.loadero.types.Browser;
-import com.loadero.types.BrowserLatest;
 import com.loadero.types.ComputeUnit;
 import com.loadero.types.Location;
 import com.loadero.types.MediaType;

--- a/src/main/java/com/loadero/model/Test.java
+++ b/src/main/java/com/loadero/model/Test.java
@@ -102,6 +102,18 @@ public final class Test {
         return ApiResource.request(RequestMethod.POST, route, null, TestRun.class);
     }
 
+    /**
+     * Duplicates test with new name.
+     * @param testId ID of the test.
+     * @param name Name of the copy.
+     * @return Copy of {@link Test} with new name and ID.
+     * @throws IOException if request failed.
+     */
+    public static Test copy(int testId, String name) throws IOException {
+        String route = buildRoute(testId) + "copy/";
+        return ApiResource.request(RequestMethod.POST, route, Test.class, name);
+    }
+
     private static String buildRoute() {
         return String.format("%s/tests/", Loadero.getProjectUrl());
     }

--- a/src/test/java/com/loadero/models/TestAsserts.java
+++ b/src/test/java/com/loadero/models/TestAsserts.java
@@ -126,4 +126,26 @@ public class TestAsserts extends AbstractTestLoadero {
         Assertions.assertNotNull(update.getExpected());
         Assertions.assertEquals(AssertOperator.GREATER_OR_EQUAL, update.getOperator());
     }
+
+    @Test
+    public void testCopyAssert() throws IOException {
+        String url = ".*/asserts/[0-9]*/";
+
+        wmRule.stubFor(get(urlMatching(url))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withBodyFile(assertsPrecondFile))
+        );
+        wmRule.stubFor(post(urlMatching(url + "copy/"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withBodyFile(assertsPrecondFile)
+            ));
+        Assert read = Assert.read(TEST_ID, ASSERT_ID);
+        Assert copy = Assert.copy(TEST_ID, ASSERT_ID);
+
+        Assertions.assertNotNull(copy);
+        Assertions.assertEquals(read.getOperator(), copy.getOperator());
+        Assertions.assertEquals(read.getPath(), copy.getPath());
+    }
 }

--- a/src/test/java/com/loadero/models/TestGroup.java
+++ b/src/test/java/com/loadero/models/TestGroup.java
@@ -121,7 +121,7 @@ public class TestGroup extends AbstractTestLoadero {
         com.loadero.model.Group group = Group.create(params);
         assertNotNull(group);
 
-        wmRule.stubFor(delete(urlMatching(".*/groups/" + group.getId()))
+        wmRule.stubFor(delete(urlMatching(".*/groups/[0-9]*/"))
             .inScenario("deleteCreate")
             .whenScenarioStateIs("created")
             .willReturn(aResponse()
@@ -129,8 +129,7 @@ public class TestGroup extends AbstractTestLoadero {
 
         // Since delete() doesn't return anything in mocked environment
         // this exception means that everything is okay
-        Assertions
-            .assertThrows(ApiException.class, () -> Group.delete(TEST_ID, GROUP_ID));
+        Group.delete(TEST_ID, GROUP_ID);
     }
 
     @Test

--- a/src/test/java/com/loadero/models/TestGroup.java
+++ b/src/test/java/com/loadero/models/TestGroup.java
@@ -132,4 +132,29 @@ public class TestGroup extends AbstractTestLoadero {
         Assertions
             .assertThrows(ApiException.class, () -> Group.delete(TEST_ID, GROUP_ID));
     }
+
+    @Test
+    public void testCopyGroup() throws IOException {
+        wmRule.stubFor(get(urlMatching(groupUrl))
+            .willReturn(aResponse()
+                .withStatus(HttpStatus.SC_OK)
+                .withBodyFile(groupJson))
+        );
+
+        wmRule.stubFor(post(urlMatching(".*/groups/[0-9]*/copy/"))
+            .willReturn(aResponse()
+                .withStatus(HttpStatus.SC_CREATED)
+                .withBodyFile(groupJson)));
+
+        wmRule.stubFor(delete(urlMatching(".*/groups/[0-9]*/"))
+            .willReturn(aResponse()
+                .withStatus(HttpStatus.SC_NO_CONTENT)));
+
+        Group original = Group.read(TEST_ID, GROUP_ID);
+        Group copy = Group.copy(TEST_ID, GROUP_ID, original.getName() + "Copy");
+
+        Assertions.assertNotNull(copy);
+        Assertions.assertEquals(original.getCount(), copy.getCount());
+        Group.delete(TEST_ID, copy.getId());
+    }
 }


### PR DESCRIPTION
Closes #4 

- Added copy() method for Test, Assert, Group and Participant along with one happy test.

- Added overloaded request() method in ApiResource to avoid unnecessary serialization issues
during copying.