### PR TITLE
readAll(): Assert model.

### DIFF
--- a/src/main/java/com/loadero/http/ApiResource.java
+++ b/src/main/java/com/loadero/http/ApiResource.java
@@ -3,6 +3,7 @@ package com.loadero.http;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.loadero.model.Assert;
+import com.loadero.model.AssertCollection;
 import com.loadero.model.Group;
 import com.loadero.model.ModelParams;
 import com.loadero.model.Participant;
@@ -73,6 +74,7 @@ public enum ApiResource {
             .registerTypeAdapter(Precondition.class, new PreconditionSerializer())
             .registerTypeAdapter(ProfileParams.class, new ProfileParamsDeserializer())
             .registerTypeAdapter(ResultAssert.class, new ResultAssertDeserializer())
+            .registerTypeAdapter(AssertCollection.class, new CollectionDeserializer<>(Assert.class))
             .setPrettyPrinting()
             .create();
     }

--- a/src/main/java/com/loadero/http/AssertDeserializer.java
+++ b/src/main/java/com/loadero/http/AssertDeserializer.java
@@ -29,7 +29,7 @@ final class AssertDeserializer implements JsonDeserializer<Assert> {
             .getConstant(jsonObject.getAsJsonPrimitive("operator").getAsString());
         List<Precondition> preconditions = new ArrayList<>();
 
-        if (jsonObject.get("preconditions") != null) {
+        if (!jsonObject.get("preconditions").isJsonNull()) {
             jsonObject.get("preconditions").getAsJsonArray()
                 .forEach(p -> preconditions.add(context.deserialize(p, Precondition.class)));
         }

--- a/src/main/java/com/loadero/http/CollectionDeserializer.java
+++ b/src/main/java/com/loadero/http/CollectionDeserializer.java
@@ -1,0 +1,35 @@
+package com.loadero.http;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.loadero.model.Assert;
+import com.loadero.model.AssertCollection;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CollectionDeserializer<T> implements JsonDeserializer<AssertCollection> {
+    private final Class<T> clazz;
+
+    public CollectionDeserializer(Class<T> clazz) {
+        this.clazz = clazz;
+    }
+
+    @Override
+    public AssertCollection deserialize(
+        JsonElement json, Type type, JsonDeserializationContext context
+    ) throws JsonParseException {
+        JsonObject jsonObject = json.getAsJsonObject();
+        System.out.println(jsonObject.toString());
+        JsonArray arr = jsonObject.getAsJsonArray("results");
+        System.out.println(arr);
+        List<Assert> asserts = new ArrayList<>();
+        arr.forEach(el -> asserts.add(ApiResource.getGSON().fromJson(el, Assert.class)));
+
+        return new AssertCollection(asserts);
+    }
+}

--- a/src/main/java/com/loadero/model/Assert.java
+++ b/src/main/java/com/loadero/model/Assert.java
@@ -45,6 +45,11 @@ public final class Assert {
         return ApiResource.request(RequestMethod.GET, route, null, Assert.class);
     }
 
+    public static AssertCollection readAll(int testId) throws IOException {
+        String route = buildRoute(testId);
+        return ApiResource.request(RequestMethod.GET, route, null, AssertCollection.class);
+    }
+
     /**
      * Creates assert.
      *

--- a/src/main/java/com/loadero/model/Assert.java
+++ b/src/main/java/com/loadero/model/Assert.java
@@ -45,9 +45,18 @@ public final class Assert {
         return ApiResource.request(RequestMethod.GET, route, null, Assert.class);
     }
 
-    public static AssertCollection readAll(int testId) throws IOException {
+    /**
+     * Returns all existing asserts.
+     *
+     * @param testId ID of the test.
+     * @return List containing {@link Assert} objects.
+     * @throws IOException if request failed.
+     */
+    public static List<Assert> readAll(int testId) throws IOException {
         String route = buildRoute(testId);
-        return ApiResource.request(RequestMethod.GET, route, null, AssertCollection.class);
+        AssertCollection collection =
+           ApiResource.request(RequestMethod.GET, route, null, AssertCollection.class);
+        return collection.getResults();
     }
 
     /**

--- a/src/main/java/com/loadero/model/AssertCollection.java
+++ b/src/main/java/com/loadero/model/AssertCollection.java
@@ -1,0 +1,9 @@
+package com.loadero.model;
+
+import java.util.List;
+
+public class AssertCollection extends LoaderoCollection<Assert> {
+    public AssertCollection(List<Assert> results) {
+        super(results);
+    }
+}

--- a/src/main/java/com/loadero/model/AssertCollection.java
+++ b/src/main/java/com/loadero/model/AssertCollection.java
@@ -2,7 +2,7 @@ package com.loadero.model;
 
 import java.util.List;
 
-public class AssertCollection extends LoaderoCollection<Assert> {
+public final class AssertCollection extends LoaderoCollection<Assert> {
     public AssertCollection(List<Assert> results) {
         super(results);
     }

--- a/src/main/java/com/loadero/model/LoaderoCollection.java
+++ b/src/main/java/com/loadero/model/LoaderoCollection.java
@@ -1,0 +1,26 @@
+package com.loadero.model;
+
+import java.util.List;
+
+public abstract class LoaderoCollection<T> {
+    private List<T> results;
+
+    public LoaderoCollection(List<T> results) {
+        this.results = results;
+    }
+
+    public List<T> getResults() {
+        return results;
+    }
+
+    public void setResults(List<T> results) {
+        this.results = results;
+    }
+
+    @Override
+    public String toString() {
+        return "LoaderoCollection{" +
+            "results=" + results +
+            '}';
+    }
+}

--- a/src/test/java/com/loadero/models/TestAsserts.java
+++ b/src/test/java/com/loadero/models/TestAsserts.java
@@ -99,10 +99,12 @@ public class TestAsserts extends AbstractTestLoadero {
             .withPath(MachineAsserts.MACHINE_CPU_PERCENT_25TH)
             .withOperator(AssertOperator.GREATER_OR_EQUAL)
             .withExpected("expected")
+            .withPreconditions(null)
             .build();
 
         Gson mockGson = new GsonBuilder()
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+            .serializeNulls()
             .create();
         System.out.println(mockGson.toJson(mockParams));
 

--- a/src/test/java/com/loadero/models/TestAsserts.java
+++ b/src/test/java/com/loadero/models/TestAsserts.java
@@ -16,6 +16,7 @@ import com.loadero.exceptions.ApiException;
 import com.loadero.model.Assert;
 import com.loadero.model.AssertCollection;
 import com.loadero.model.AssertParams;
+import com.loadero.model.LoaderoCollection;
 import com.loadero.types.AssertOperator;
 import com.loadero.types.MachineAsserts;
 import com.loadero.types.WebRtcAsserts;
@@ -152,9 +153,7 @@ public class TestAsserts extends AbstractTestLoadero {
 
     @Test
     public void testReadAll() throws IOException {
-        AssertCollection assertList = Assert.readAll(TEST_ID);
-        System.out.println(assertList);
-        System.out.println(assertList.getResults().get(0));
+        List<Assert> assertList = Assert.readAll(TEST_ID);
         Assertions.assertNotNull(assertList);
     }
 }

--- a/src/test/java/com/loadero/models/TestAsserts.java
+++ b/src/test/java/com/loadero/models/TestAsserts.java
@@ -26,6 +26,7 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 public class TestAsserts extends AbstractTestLoadero {
     private static final String assertsPrecondFile = "body-asserts-precond.json";
@@ -152,6 +153,7 @@ public class TestAsserts extends AbstractTestLoadero {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "LOADERO_BASE_URL", matches = ".*localhost.*")
     public void testReadAll() throws IOException {
         List<Assert> assertList = Assert.readAll(TEST_ID);
         Assertions.assertNotNull(assertList);

--- a/src/test/java/com/loadero/models/TestAsserts.java
+++ b/src/test/java/com/loadero/models/TestAsserts.java
@@ -14,15 +14,16 @@ import com.loadero.AbstractTestLoadero;
 import com.loadero.Loadero;
 import com.loadero.exceptions.ApiException;
 import com.loadero.model.Assert;
+import com.loadero.model.AssertCollection;
 import com.loadero.model.AssertParams;
 import com.loadero.types.AssertOperator;
 import com.loadero.types.MachineAsserts;
 import com.loadero.types.WebRtcAsserts;
 import java.io.IOException;
+import java.util.List;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class TestAsserts extends AbstractTestLoadero {
@@ -147,5 +148,13 @@ public class TestAsserts extends AbstractTestLoadero {
         Assertions.assertNotNull(copy);
         Assertions.assertEquals(read.getOperator(), copy.getOperator());
         Assertions.assertEquals(read.getPath(), copy.getPath());
+    }
+
+    @Test
+    public void testReadAll() throws IOException {
+        AssertCollection assertList = Assert.readAll(TEST_ID);
+        System.out.println(assertList);
+        System.out.println(assertList.getResults().get(0));
+        Assertions.assertNotNull(assertList);
     }
 }

--- a/src/test/resources/__files/body-asserts-no-precond.json
+++ b/src/test/resources/__files/body-asserts-no-precond.json
@@ -5,5 +5,6 @@
   "path": "webrtc/audio/jitter/25th",
   "operator": "lt",
   "expected": "23234",
-  "test_id": 6866
+  "test_id": 6866,
+  "preconditions": null
 }


### PR DESCRIPTION
Closes #5 

Submitting `readAll()` implementation for Assert model.
Basically, implementation for other models for `readAll()` will be similar to this one.