### PR TITLE
Changed Location enum's names from AWS to city names.

### DIFF
--- a/src/main/java/com/loadero/types/Location.java
+++ b/src/main/java/com/loadero/types/Location.java
@@ -7,29 +7,29 @@ import com.google.gson.annotations.SerializedName;
  */
 public enum Location {
     @SerializedName("eu-central-1")
-    EU_CENTRAL_1("eu-central-1"),
+    FRANKFURT("eu-central-1"),
     @SerializedName("eu-west-1")
-    EU_WEST_1("eu-west-1"),
+    IRELAND("eu-west-1"),
     @SerializedName("eu-west-3")
-    EU_WEST_3("eu-west-3"),
-    @SerializedName("ap-northwest-1")
-    AP_NORTHEAST_1("ap-northeast-1"),
+    PARIS("eu-west-3"),
+    @SerializedName("ap-northeast-1")
+    TOKYO("ap-northeast-1"),
     @SerializedName("ap-southeast-2")
-    AP_SOUTHEAST_2("ap-southeast-2"),
+    SYDNEY("ap-southeast-2"),
     @SerializedName("ap-east-1")
-    AP_EAST_1("ap-east-1"),
+    HONG_KONG("ap-east-1"),
     @SerializedName("ap-south-1")
-    AP_SOUTH_1("ap-south-1"),
+    MUMBAI("ap-south-1"),
     @SerializedName("us-east-1")
-    US_EAST_1("us-east-1"),
+    NORTH_VIRGINIA("us-east-1"),
     @SerializedName("us-east-2")
-    US_EAST_2("us-east-2"),
+    OHIO("us-east-2"),
     @SerializedName("us-west-2")
-    US_WEST_2("us-west-2"),
+    OREGON("us-west-2"),
     @SerializedName("sa-east-1")
-    SA_EAST_1("sa-east-1"),
+    SAO_PAULO("sa-east-1"),
     @SerializedName("ap-northeast-2")
-    AP_NORTHEAST_2("ap-northeast-2");
+    SEOUL("ap-northeast-2");
 
     private final String label;
     private static final EnumLookupHelper<Location> helper = new EnumLookupHelper<>(values());

--- a/src/test/java/com/loadero/models/LoaderoTest.java
+++ b/src/test/java/com/loadero/models/LoaderoTest.java
@@ -14,6 +14,7 @@ import com.loadero.exceptions.ApiException;
 import com.loadero.model.Script;
 import com.loadero.model.TestParams;
 import com.loadero.types.IncrementStrategy;
+import com.loadero.types.Location;
 import com.loadero.types.TestMode;
 import java.io.IOException;
 import java.time.Duration;
@@ -209,5 +210,12 @@ public class LoaderoTest extends AbstractTestLoadero {
         Assertions.assertEquals(original.getMode(), copy.getMode());
 
         com.loadero.model.Test.delete(copy.getId());
+    }
+
+    @Test
+    public void testEnumLocation() {
+        Assertions.assertEquals(Location.FRANKFURT.toString(), "eu-central-1");
+        Assertions.assertEquals(Location.TOKYO.toString(), "ap-northeast-1");
+        Assertions.assertEquals(Location.SAO_PAULO.toString(), "sa-east-1");
     }
 }

--- a/src/test/java/com/loadero/models/TestParticipant.java
+++ b/src/test/java/com/loadero/models/TestParticipant.java
@@ -81,8 +81,6 @@ public class TestParticipant extends AbstractTestLoadero {
             .build();
         com.loadero.model.Participant create = com.loadero.model.Participant.create(params);
         assertNotNull(create);
-        System.out.println(Location.FRANKFURT);
-        System.out.println(create.getLocation());
         com.loadero.model.Participant
             .delete(create.getTestId(), create.getGroupId(), create.getId());
     }

--- a/src/test/java/com/loadero/models/TestParticipant.java
+++ b/src/test/java/com/loadero/models/TestParticipant.java
@@ -70,7 +70,7 @@ public class TestParticipant extends AbstractTestLoadero {
             .builder()
             .withName("participant1")
             .withCount(1)
-            .withLocation(Location.EU_WEST_1)
+            .withLocation(Location.OREGON)
             .withNetwork(Network.DEFAULT)
             .withBrowser(new Browser(BrowserLatest.CHROME_LATEST))
             .withComputeUnit(ComputeUnit.G2)
@@ -81,6 +81,8 @@ public class TestParticipant extends AbstractTestLoadero {
             .build();
         com.loadero.model.Participant create = com.loadero.model.Participant.create(params);
         assertNotNull(create);
+        System.out.println(Location.FRANKFURT);
+        System.out.println(create.getLocation());
         com.loadero.model.Participant
             .delete(create.getTestId(), create.getGroupId(), create.getId());
     }


### PR DESCRIPTION
Closes #2 

Renamed Location Enum values to city names, so that now user can use something like this `Location.FRANKFURT` to set location and this will be serialized/deserialized into respective AWS instance's name i.e. **eu-central-1**. 

- Adjusted tests, added one to check that enums maps nicely.

