### PR TITLE
Added alternative serialization name for Location enum.

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Add <b>JitPack</b> repository and <b>loadero-java</b> dependency with recent ver
     <dependency>
           <groupId>com.github.loadero</groupId>
 	  <artifactId>loadero-java</artifactId>
-	  <version>1.0.1</version>
+	  <version>1.1.2</version>
     </dependency>
 </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.loadero</groupId>
     <artifactId>loadero-java</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/com/loadero/types/Location.java
+++ b/src/main/java/com/loadero/types/Location.java
@@ -6,29 +6,29 @@ import com.google.gson.annotations.SerializedName;
  * Contains values that can be used to set location for a {@link com.loadero.model.Participant}.
  */
 public enum Location {
-    @SerializedName("eu-central-1")
+    @SerializedName(value = "eu-central-1", alternate = "frankfurt")
     FRANKFURT("eu-central-1"),
-    @SerializedName("eu-west-1")
+    @SerializedName(value = "eu-west-1", alternate = "ireland")
     IRELAND("eu-west-1"),
-    @SerializedName("eu-west-3")
+    @SerializedName(value = "eu-west-3", alternate = "paris")
     PARIS("eu-west-3"),
-    @SerializedName("ap-northeast-1")
+    @SerializedName(value = "ap-northeast-1", alternate = "tokyo")
     TOKYO("ap-northeast-1"),
-    @SerializedName("ap-southeast-2")
+    @SerializedName(value = "ap-southeast-2", alternate = "sydney")
     SYDNEY("ap-southeast-2"),
-    @SerializedName("ap-east-1")
+    @SerializedName(value = "ap-east-1", alternate = "hong-kong")
     HONG_KONG("ap-east-1"),
-    @SerializedName("ap-south-1")
+    @SerializedName(value = "ap-south-1", alternate = "mumbai")
     MUMBAI("ap-south-1"),
-    @SerializedName("us-east-1")
+    @SerializedName(value = "us-east-1", alternate = "north virginia")
     NORTH_VIRGINIA("us-east-1"),
-    @SerializedName("us-east-2")
+    @SerializedName(value = "us-east-2", alternate = "ohio")
     OHIO("us-east-2"),
-    @SerializedName("us-west-2")
+    @SerializedName(value = "us-west-2", alternate = "oregon")
     OREGON("us-west-2"),
-    @SerializedName("sa-east-1")
+    @SerializedName(value = "sa-east-1", alternate = "sao-paulo")
     SAO_PAULO("sa-east-1"),
-    @SerializedName("ap-northeast-2")
+    @SerializedName(value = "ap-northeast-2", alternate = "seoul")
     SEOUL("ap-northeast-2");
 
     private final String label;

--- a/src/main/java/com/loadero/types/Location.java
+++ b/src/main/java/com/loadero/types/Location.java
@@ -20,7 +20,7 @@ public enum Location {
     HONG_KONG("ap-east-1"),
     @SerializedName(value = "ap-south-1", alternate = "mumbai")
     MUMBAI("ap-south-1"),
-    @SerializedName(value = "us-east-1", alternate = "north virginia")
+    @SerializedName(value = "us-east-1", alternate = "north-virginia")
     NORTH_VIRGINIA("us-east-1"),
     @SerializedName(value = "us-east-2", alternate = "ohio")
     OHIO("us-east-2"),

--- a/src/test/java/com/loadero/models/LoaderoTest.java
+++ b/src/test/java/com/loadero/models/LoaderoTest.java
@@ -216,11 +216,8 @@ public class LoaderoTest extends AbstractTestLoadero {
 
     @Test
     public void testEnumLocation() {
-        Assertions.assertEquals(Location.FRANKFURT, Location.getConstant("frankfurt"));
         Assertions.assertEquals(Location.FRANKFURT, Location.getConstant("eu-central-1"));
         Assertions.assertEquals(Location.HONG_KONG, Location.getConstant("ap-east-1"));
-        Assertions.assertEquals(Location.HONG_KONG, Location.getConstant("hong-kong"));
-        Assertions.assertNotEquals(Location.HONG_KONG, Location.getConstant("oregon"));
         Assertions.assertEquals(Location.FRANKFURT.toString(), "eu-central-1");
         Assertions.assertEquals(Location.TOKYO.toString(), "ap-northeast-1");
         Assertions.assertEquals(Location.SAO_PAULO.toString(), "sa-east-1");

--- a/src/test/java/com/loadero/models/LoaderoTest.java
+++ b/src/test/java/com/loadero/models/LoaderoTest.java
@@ -216,6 +216,11 @@ public class LoaderoTest extends AbstractTestLoadero {
 
     @Test
     public void testEnumLocation() {
+        Assertions.assertEquals(Location.FRANKFURT, Location.getConstant("frankfurt"));
+        Assertions.assertEquals(Location.FRANKFURT, Location.getConstant("eu-central-1"));
+        Assertions.assertEquals(Location.HONG_KONG, Location.getConstant("ap-east-1"));
+        Assertions.assertEquals(Location.HONG_KONG, Location.getConstant("hong-kong"));
+        Assertions.assertNotEquals(Location.HONG_KONG, Location.getConstant("oregon"));
         Assertions.assertEquals(Location.FRANKFURT.toString(), "eu-central-1");
         Assertions.assertEquals(Location.TOKYO.toString(), "ap-northeast-1");
         Assertions.assertEquals(Location.SAO_PAULO.toString(), "sa-east-1");

--- a/src/test/java/com/loadero/models/TestParticipant.java
+++ b/src/test/java/com/loadero/models/TestParticipant.java
@@ -122,4 +122,40 @@ public class TestParticipant extends AbstractTestLoadero {
         List<Participant> participants = Participant.readAll(TEST_ID, GROUP_ID);
         Assertions.assertNotNull(participants);
     }
+
+    @Test
+    public void testLocationDeserialization() {
+        String configJson1 = "frankfurt";
+        String configJson2 = "sao-paulo";
+        String configJson3 = "hong-kong";
+        Location config1 = gson.fromJson(configJson1, Location.class);
+        Location config2 = gson.fromJson(configJson2, Location.class);
+        Location config3 = gson.fromJson(configJson3, Location.class);
+        Assertions.assertEquals(Location.FRANKFURT, config1);
+        Assertions.assertEquals(Location.SAO_PAULO, config2);
+        Assertions.assertEquals(Location.HONG_KONG, config3);
+    }
+}
+
+class ParticipantConfig {
+    private Location location;
+
+    public ParticipantConfig(Location location) {
+        this.location = location;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public void setLocation(Location location) {
+        this.location = location;
+    }
+
+    @Override
+    public String toString() {
+        return "ParticipantConfig{" +
+            "location=" + location +
+            '}';
+    }
 }

--- a/src/test/java/com/loadero/models/TestParticipant.java
+++ b/src/test/java/com/loadero/models/TestParticipant.java
@@ -128,34 +128,14 @@ public class TestParticipant extends AbstractTestLoadero {
         String configJson1 = "frankfurt";
         String configJson2 = "sao-paulo";
         String configJson3 = "hong-kong";
+        String configJson4 = "north-virginia";
         Location config1 = gson.fromJson(configJson1, Location.class);
         Location config2 = gson.fromJson(configJson2, Location.class);
         Location config3 = gson.fromJson(configJson3, Location.class);
+        Location config4 = gson.fromJson(configJson4, Location.class);
         Assertions.assertEquals(Location.FRANKFURT, config1);
         Assertions.assertEquals(Location.SAO_PAULO, config2);
         Assertions.assertEquals(Location.HONG_KONG, config3);
-    }
-}
-
-class ParticipantConfig {
-    private Location location;
-
-    public ParticipantConfig(Location location) {
-        this.location = location;
-    }
-
-    public Location getLocation() {
-        return location;
-    }
-
-    public void setLocation(Location location) {
-        this.location = location;
-    }
-
-    @Override
-    public String toString() {
-        return "ParticipantConfig{" +
-            "location=" + location +
-            '}';
+        Assertions.assertEquals(Location.NORTH_VIRGINIA, config4);
     }
 }


### PR DESCRIPTION
Closes #24 

One caveat though. City names that have spaces should be written with hyphen instead i.e. "north virginia" -> "north-virginia". Otherwise default serialization of alternative name may fail. 

- Now can serialize into object from city names as well.
- Added happy path tests to check functionality.
- Bumped version in pom.xml and README